### PR TITLE
feat: introduce monaco editor

### DIFF
--- a/packages/monaco/index.html
+++ b/packages/monaco/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <script type="module" src="src/index.ts"></script>
+  </body>
+</html>

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "inpageedit-plugin-monaco",
+  "description": "Monaco Editor for InPageEdit",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "module": "./dist/index.mjs",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "$ipe": {
+    "name": "Monaco Editor",
+    "categories": [],
+    "loader": {
+      "kind": "module",
+      "entry": "dist/index.mjs",
+      "styles": [],
+      "main_export": "default"
+    },
+    "dev_loader": {
+      "entry": "src/index.ts",
+      "styles": []
+    }
+  },
+  "dependencies": {
+    "modern-monaco": "^0.2.2"
+  },
+  "devDependencies": {
+    "rolldown": "1.0.0-beta.47",
+    "vite": "npm:rolldown-vite@latest"
+  }
+}

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -1,0 +1,112 @@
+import { BasePlugin } from '~~/defineIPEPlugin.js'
+import type { Events, InPageEdit } from '@inpageedit/core'
+import type {} from '@inpageedit/core/services/WikiTitleService'
+import type {} from '@inpageedit/core/plugins/toolbox/index'
+import type {} from '@inpageedit/core/plugins/quick-edit/index'
+import { IWikiPage } from '@inpageedit/core/dist/models/WikiPage/index.js'
+
+export class PluginMonaco extends BasePlugin {
+  constructor(ctx: InPageEdit) {
+    super(ctx, {}, 'monaco-editor')
+    ctx.set('plugin:monaco-editor', true)
+  }
+
+  protected async start() {
+    this.ctx.on('quick-edit/wiki-page', this.onQuickEditWikiPage.bind(this))
+  }
+
+  async onQuickEditWikiPage(
+    payload: Parameters<Events['quick-edit/wiki-page']>[0]
+  ) {
+    const { init } = await import('modern-monaco')
+
+    const { modal, wikiPage } = payload
+    const textarea = modal
+      .get$content()
+      .querySelector<HTMLTextAreaElement>('textarea[name="text"]')
+    const wrapper = modal
+      .get$content()
+      .querySelector<HTMLDivElement>('.ipe-quickEdit__content')
+    if (!textarea || !wrapper) return
+
+    const language =
+      wikiPage.contentmodel ||
+      this.guessLangByTitle(wikiPage.title) ||
+      'wikitext'
+    const monaco = await init({})
+    const container = document.createElement('div')
+    container.style.width = wrapper.clientWidth + 'px'
+    container.style.height = '65lvh'
+    wrapper.appendChild(container)
+    const editor = monaco.editor.create(container, {
+      theme: 'vs-dark',
+      automaticLayout: true,
+      language,
+      tabSize: 2,
+      glyphMargin: true,
+      wordWrap: language === 'wikitext' ? 'on' : 'off',
+      wordBreak: language === 'wikitext' ? 'keepAll' : 'normal',
+      unicodeHighlight:
+        language === 'wikitext'
+          ? {
+              ambiguousCharacters: false,
+            }
+          : undefined,
+    })
+    const model = this.createModel(monaco, wikiPage)
+    editor.setModel(model)
+    model.onDidChangeAttached(() => {
+      textarea.value = model.getValue()
+      textarea.dispatchEvent(new Event('input'))
+      textarea.dispatchEvent(new Event('change'))
+    })
+  }
+
+  guessLangByTitle(input = '') {
+    const title = this.ctx.wikiTitle.newTitle(input)
+    const nsNumber = title.getNamespaceId()
+    const pageName = title.getMainText()
+    const ext = pageName.split('.').pop()
+    if (ext === 'js') {
+      return 'javascript'
+    } else if (ext === 'css') {
+      return 'css'
+    }
+    // NS_MODULE
+    else if (nsNumber === 828 && !pageName.endsWith('/doc')) {
+      return 'lua'
+    }
+    // NS_WIDGET
+    else if (nsNumber === 274) {
+      return 'html'
+    } else if (ext === 'json') {
+      return 'json'
+    }
+    return 'wikitext'
+  }
+
+  async createWorkspace(wikiPage: IWikiPage) {
+    const { Workspace } = await import('modern-monaco')
+    const workspace = new Workspace({
+      name: wikiPage.title,
+      initialFiles: {
+        [wikiPage.title]: wikiPage.revisions?.[0]?.content || '',
+      },
+      entryFile: wikiPage.title,
+    })
+    workspace.openTextDocument(wikiPage.title)
+    return workspace
+  }
+
+  createModel(
+    monaco: Awaited<ReturnType<typeof import('modern-monaco').init>>,
+    wikiPage: IWikiPage
+  ) {
+    return monaco.editor.createModel(
+      wikiPage.revisions?.[0]?.content || '',
+      wikiPage.contentmodel ||
+        this.guessLangByTitle(wikiPage.title) ||
+        'wikitext'
+    )
+  }
+}

--- a/packages/monaco/vite.config.ts
+++ b/packages/monaco/vite.config.ts
@@ -1,0 +1,24 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es'],
+      fileName: () => 'index.mjs',
+      cssFileName: 'style.css',
+    },
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: false,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '~~': resolve(import.meta.dirname, '../../common'),
+    },
+  },
+})


### PR DESCRIPTION
## Sourcery 总结

为 InPageEdit 引入一个新的 Monaco 编辑器插件，该插件在快速编辑维基模态框中嵌入了一个由 Monaco 提供支持的代码编辑器，并将其打包为一个 ESM 库。

新功能：
- 将 Monaco 编辑器实例附加到 quick-edit/wiki-page 事件，用现代 Monaco 编辑器替换文本区域。
- 动态加载并初始化现代 Monaco，其主题、布局和语言设置从页面内容模型或文件名推断而来。
- 提供辅助方法，通过标题扩展名/命名空间猜测语言、创建 Monaco 模型，并使用维基页面内容设置工作区。

构建：
- 添加 package.json 文件，其中包含模块导出、构建脚本和 InPageEdit 插件元数据。
- 配置 Vite 以输出 ES 模块库，并包含一个开发用的 HTML 入口点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new Monaco Editor plugin for InPageEdit that embeds a monaco-powered code editor in the quick-edit wiki modal and packages it as an ESM library.

New Features:
- Attach a Monaco Editor instance to the quick-edit/wiki-page event, replacing the textarea with a modern-monaco editor
- Dynamically load and initialize modern-monaco with theme, layout, and language settings inferred from the page content model or filename
- Provide helper methods to guess language by title extension/namespace, create monaco models, and set up workspaces with wiki page content

Build:
- Add package.json with module exports, build scripts, and plugin metadata for InPageEdit
- Configure Vite for ES module library output and include a development HTML entry point

</details>