### PR TITLE
fix(wiki-editor): no duplicate buttons

### DIFF
--- a/packages/code-mirror/src/index.ts
+++ b/packages/code-mirror/src/index.ts
@@ -21,11 +21,16 @@ export default defineIPEPlugin({
     ctx.on(
       'quick-edit/wiki-page',
       async ({ modal, wikiPage: { contentmodel, ns, title } }) => {
-        const pkg = await import(
-          // @ts-ignore
-          /* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/@bhsd/codemirror-mediawiki/dist/mw.min.js'
-        )
-        const { CodeMirror } = pkg
+        let CodeMirror
+        if (typeof CodeMirror6 === 'function') {
+          CodeMirror = CodeMirror6
+        } else {
+          const pkg = await import(
+            // @ts-ignore
+            /* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/@bhsd/codemirror-mediawiki/dist/mw.min.js'
+          );
+          ({ CodeMirror } = pkg)
+        }
         CodeMirror.fromTextArea(
           modal
             .get$content()

--- a/packages/wiki-editor/src/index.ts
+++ b/packages/wiki-editor/src/index.ts
@@ -27,9 +27,10 @@ export default defineIPEPlugin({
       if (!textarea || !registered) {
         return
       }
-      await mw.loader.using(['ext.wikiEditor'])
       if (typeof window.mw?.addWikiEditor === 'function') {
         window.mw.addWikiEditor($(textarea))
+      } else {
+        await mw.loader.using(['ext.wikiEditor'])
       }
     })
   },

--- a/packages/wiki-editor/src/index.ts
+++ b/packages/wiki-editor/src/index.ts
@@ -19,7 +19,7 @@ export default defineIPEPlugin({
   name: 'wiki-editor',
   apply(ctx) {
     ctx.set('plugin:wiki-editor', ctx.scope)
-    ctx.on('quick-edit/wiki-page', async (payload) => {
+    ctx.on('quick-edit/wiki-page', (payload) => {
       const textarea = payload.modal
         .get$content()
         .querySelector<HTMLTextAreaElement>('textarea[name="text"]')!
@@ -30,7 +30,7 @@ export default defineIPEPlugin({
       if (typeof window.mw?.addWikiEditor === 'function') {
         window.mw.addWikiEditor($(textarea))
       } else {
-        await mw.loader.using(['ext.wikiEditor'])
+        mw.loader.load(['ext.wikiEditor'])
       }
     })
   },


### PR DESCRIPTION
WikiEditor toolbars are automatically loaded for textareas with `id="wpTextbox1"`.

close #11

## Sourcery 总结

错误修复:
- 通过推迟 ext.wikiEditor 加载直到需要时，防止重复的 wiki 编辑器工具栏按钮

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate wiki-editor toolbar buttons by deferring ext.wikiEditor loading until needed

</details>