### PR TITLE
fix(code-mirror): style conflict with IPE modal

### DIFF
--- a/packages/code-mirror/package.json
+++ b/packages/code-mirror/package.json
@@ -26,12 +26,16 @@
     "loader": {
       "kind": "module",
       "entry": "dist/index.mjs",
-      "styles": [],
+      "styles": [
+        "dist/style.css"
+      ],
       "main_export": "default"
     },
     "dev_loader": {
       "entry": "src/index.ts",
-      "styles": []
+      "styles": [
+        "src/style.scss"
+      ]
     }
   }
 }

--- a/packages/code-mirror/src/index.ts
+++ b/packages/code-mirror/src/index.ts
@@ -1,3 +1,5 @@
+import './style.scss'
+
 import { defineIPEPlugin } from '~~/defineIPEPlugin.js'
 import type { ForkScope } from '@cordisjs/core'
 

--- a/packages/code-mirror/src/style.scss
+++ b/packages/code-mirror/src/style.scss
@@ -1,3 +1,3 @@
-.ipe-quickEdit__form .cm-editor {
+.ipe-quickEdit__form .wikiEditor-ui-view .cm-editor {
   overflow-y: visible;
 }

--- a/packages/code-mirror/src/style.scss
+++ b/packages/code-mirror/src/style.scss
@@ -1,0 +1,3 @@
+.ipe-quickEdit__form .cm-editor {
+  overflow-y: visible;
+}


### PR DESCRIPTION
The style `.cm-editor { overflow-y: hidden }` was designed for some specific layouts of textareas, which does not apply to IPE.

## 由 Sourcery 提供的摘要

错误修复：
- 通过允许 IPE 快速编辑表单中的 CodeMirror 编辑器在垂直方向上扩展，修复垂直溢出被裁剪的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix vertical overflow clipping by allowing the CodeMirror editor inside IPE quick edit forms to expand vertically.

</details>