### PR TITLE
Update code-mirror

### DIFF
--- a/packages/code-mirror/src/index.ts
+++ b/packages/code-mirror/src/index.ts
@@ -25,7 +25,7 @@ export default defineIPEPlugin({
         : (async () => {
           const pkg = await import(
             // @ts-ignore
-            /* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/@bhsd/codemirror-mediawiki/dist/mw.min.js'
+            /* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/@bhsd/codemirror-mediawiki@3/dist/mw.min.js'
           )
           return pkg.CodeMirror
         })()


### PR DESCRIPTION
There will be break changes in `@bhsd/codemirror-mediawiki@4`.

## Summary by Sourcery

Enhancements:
- 将外部的 CodeMirror MediaWiki 脚本 URL 从指向最新版本改为明确指定为版本 3。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update the external CodeMirror MediaWiki script URL to explicitly target version 3 instead of the latest release.

</details>